### PR TITLE
Add multi-tenant updates, fix sharding and add deleteOnly option.

### DIFF
--- a/benchmarker/cmd/config.go
+++ b/benchmarker/cmd/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	HttpScheme             string
 	UpdatePercentage       float64
 	UpdateRandomized       bool
+	DeleteOnly             bool
 	UpdateIterations       int
 	Offset                 int
 	CleanupIntervalSeconds int


### PR DESCRIPTION
This commit adds the option to perform updates when a numTenants larger than 0 is provided. Also, adds the ShardingConfig in the schema creation to ensure that the number of shards passed in the option is configured.

Last, but not least, it adds a deleteOnly option that allows testing if the number of objects decreases when performing a delete (as with updates it is not possible).